### PR TITLE
add bucket logging as part of success / fail log

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,9 +51,9 @@ module.exports = function (aws, options) {
 
       client.putBuffer(file.contents, uploadPath, headers, function(err, res) {
         if (err || res.statusCode !== 200) {
-          gutil.log(gutil.colors.red('[FAILED]', file.path + " -> " + uploadPath));
+          gutil.log(gutil.colors.red('[FAILED]', file.path + " -> " + aws.bucket + uploadPath));
         } else {
-          gutil.log(gutil.colors.green('[SUCCESS]', file.path + " -> " + uploadPath));
+          gutil.log(gutil.colors.green('[SUCCESS]', file.path + " -> " + aws.bucket + uploadPath));
           res.resume();
         }
       });


### PR DESCRIPTION
If you are uploading the same / similar files to multiple buckets, you can't tell which bucket failed