### PR TITLE
removing the acl public-read permission header. we should not assume tha...

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = function (aws, options) {
 
       var uploadPath = file.path.replace(file.base, options.uploadPath || '');
       uploadPath = uploadPath.replace(new RegExp('\\\\', 'g'), '/');
-      var headers = { 'x-amz-acl': 'public-read' };
+      var headers = {};
       if (options.headers) {
           for (var key in options.headers) {
               headers[key] = options.headers[key];


### PR DESCRIPTION
I have removed the hard coded x-amz-acl header (set to public-read) we should not assume that the credentials being used have that permission. If it is something that needs to be set then it should be explicitly stated on a per use case bases. What do you think?