### PR TITLE
adding ability to test deploy process / upload process via dry run arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ Setup your aws.json file
 {
   "key": "AKIAI3Z7CUAFHG53DMJA",
   "secret": "acYxWRu5RRa6CwzQuhdXEfTpbQA+1XQJ7Z1bGTCx",
-  "bucket": "dev.example.com",
-  "region": "eu-west-1"
+  "bucket": "dev.example.com"
 }
 ```
 
@@ -24,9 +23,16 @@ Then, use it in your `gulpfile.js`:
 ```javascript
 var s3 = require("gulp-s3");
 
-aws = JSON.parse(fs.readFileSync('./aws.json'));
+aws = require('./aws.json');
 gulp.src('./dist/**')
     .pipe(s3(aws));
+```
+
+## Testing
+To test your paths before uploading add the 'dry' flag to your gulp command.
+
+```
+gulp deploy --dry
 ```
 
 ## API
@@ -59,9 +65,8 @@ var gzip = require("gulp-gzip");
 var options = { gzippedOnly: true };
 
 gulp.src('./dist/**')
-.pipe(gzip())
-.pipe(s3(aws, options));
-
+  .pipe(gzip())
+  .pipe(s3(aws, options));
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "event-stream": "*",
     "gulp-util": "~2.2.6",
     "knox": "",
-    "mime": "~1.2.11"
+    "mime": "~1.2.11",
+    "yargs": "^3.6.0"
   },
   "devDependencies": {
     "mocha": "~1.14.0",


### PR DESCRIPTION
This PR is to add the ability to add a --dry flag to gulp commands in order to preview upload paths to s3